### PR TITLE
Update __init__.py (remove deprecated use of `ModelFilter`)

### DIFF
--- a/grazier/engines/llm/__init__.py
+++ b/grazier/engines/llm/__init__.py
@@ -2,7 +2,7 @@ import logging
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Type, TypeVar
 
-from huggingface_hub import HfApi, ModelFilter
+from huggingface_hub import HfApi
 
 from grazier.engines.default import Engine
 from grazier.utils.pytorch import select_device
@@ -55,7 +55,7 @@ class LLMEngine(Engine):
 
         logging.info(f"Failed to find local LLM matching {typestr}. Fetching remote LLMs...")
         api = HfApi()
-        models = list(api.list_models(filter=ModelFilter(model_name=typestr, task="text-generation")))
+        models = list(api.list_models(model_name=typestr, task="text-generation"))
         if len(models) > 0:
             return HuggingFaceTextGenerationLMEngine.from_hub_model(typestr)(**kwargs)  # noqa: F405
 


### PR DESCRIPTION
This PR remove deprecated use of `ModelFilter`. Arguments can now be passed to `list_models` directly. See https://github.com/huggingface/huggingface_hub/issues/2028 for more details.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the `__init__.py` file to remove the deprecated use of `ModelFilter` by passing arguments directly to the `list_models` function.

Enhancements:
- Remove deprecated use of `ModelFilter` in the `list_models` function call, allowing arguments to be passed directly.

<!-- Generated by sourcery-ai[bot]: end summary -->